### PR TITLE
Fixed issue #1, caused by out-of-ordered Page and Network events.

### DIFF
--- a/lib/PuppeteerHar.js
+++ b/lib/PuppeteerHar.js
@@ -3,12 +3,15 @@ const { promisify } = require('util');
 const { harFromMessages } = require('chrome-har');
 
 // event types to observe
-const observe = [
+const page_observe = [
     'Page.loadEventFired',
     'Page.domContentEventFired',
     'Page.frameStartedLoading',
     'Page.frameAttached',
     'Page.frameScheduledNavigation',
+];
+
+const network_observe = [
     'Network.requestWillBeSent',
     'Network.requestServedFromCache',
     'Network.dataReceived',
@@ -26,7 +29,8 @@ class PuppeteerHar {
     constructor(page) {
         this.page = page;
         this.mainFrame = this.page.mainFrame();
-        this.events = [];
+        this.network_events = [];
+        this.page_events = [];
     }
 
     /**
@@ -38,9 +42,14 @@ class PuppeteerHar {
         this.client = await this.page.target().createCDPSession();
         await this.client.send('Page.enable');
         await this.client.send('Network.enable');
-        observe.forEach(async method => {
-            await this.client.on(method, params => {
-                this.events.push({ method, params });
+        page_observe.forEach(method => {
+            this.client.on(method, params => {
+                this.page_events.push({ method, params });
+            });
+        });
+        network_observe.forEach(method => {
+            this.client.on(method, params => {
+                this.network_events.push({ method, params });
             });
         });
     }
@@ -50,7 +59,9 @@ class PuppeteerHar {
      */
     async stop() {
         await this.client.detach();
-        const har = harFromMessages(this.events);
+        const har = harFromMessages(
+            this.page_events.concat(this.network_events)
+        );
         if (this.path) {
             await promisify(fs.writeFile)(this.path, JSON.stringify(har));
         } else {


### PR DESCRIPTION
I believe I have fixed issue #1 and sending a PR.

Recently, puppeteer-har started to generate incomplete HAR that does not include many resources in a page, including basepage HTML. After tracing down the cause, I believe the cause is same as the one discussed in  https://github.com/Everettss/puppeteer-har/issues/1 or https://github.com/sitespeedio/chrome-har/issues/15 .

The reason for breakage is that Puppeteer does not ensure order betweek Page and Network events.
Each event type comes in ordered manner, but it does not ensure expected Page event to come before Network events.

Going through the chrome-har code, the simple fix was to just have Page events prepended to Network events. So here it is.

