### PR TITLE
Set peerDependency on puppeteer-core instead of puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chrome-har": "^0.11.3"
   },
   "peerDependencies": {
-    "puppeteer": ">=1.0.0"
+    "puppeteer-core": ">=1.0.0"
   },
   "engines": {
     "node": ">=7.6.0"


### PR DESCRIPTION
Libraries and applications that depend on `puppeteer-core`, but not `puppeteer` can still use `puppeteer-har`.

This change just reflects this information in `peerDependencies`.

https://pptr.dev/#?product=Puppeteer&version=v2.1.0&show=api-puppeteer-vs-puppeteer-core