### PR TITLE
Make response body inclusion logic dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ const PuppeteerHar = require('puppeteer-har');
 ### har.start([options])
 - `options` <?[Object]> Optional
   - `path` <[string]> If set HAR file will be written at this path
+  - `includeResponseBody` <[boolean]> Function that evaluates the Puppeteer `Response` and returns `true` if its body should also be added (as a <[string]>)
 - returns: <[Promise]>
 
 ### har.stop()

--- a/lib/PuppeteerHar.js
+++ b/lib/PuppeteerHar.js
@@ -29,7 +29,7 @@ class PuppeteerHar {
     constructor(page) {
         this.page = page;
         this.mainFrame = this.page.mainFrame();
-        this.inProgress = false; 
+        this.inProgress = false;
         this.cleanUp();
     }
 
@@ -46,11 +46,15 @@ class PuppeteerHar {
      * @param {{path: string}=} options
      * @return {Promise<void>}
      */
-    async start({ path, saveResponse, captureMimeTypes } = {}) {
+    async start({ path, includeResponseBody, saveResponse, captureMimeTypes } = {}) {
         this.inProgress = true;
-        this.saveResponse = saveResponse || false;
-        this.captureMimeTypes = captureMimeTypes || ['text/html', 'application/json'];
         this.path = path;
+        if (includeResponseBody != null) {
+            this.includeResponseBody = includeResponseBody;
+        } else if (saveResponse) {
+            captureMimeTypes = new Set(captureMimeTypes ?? ['text/html', 'application/json']);
+            this.includeResponseBody = (response) => captureMimeTypes.has(response.mimeType);
+        }
         this.client = await this.page.target().createCDPSession();
         await this.client.send('Page.enable');
         await this.client.send('Network.enable');
@@ -69,14 +73,14 @@ class PuppeteerHar {
                 }
                 this.network_events.push({ method, params });
 
-                if (this.saveResponse && method == 'Network.responseReceived') {
+                if (this.includeResponseBody != null && method == 'Network.responseReceived') {
                     const response = params.response;
                     const requestId = params.requestId;
-                    
+
                     // Response body is unavailable for redirects, no-content, image, audio and video responses
                     if (response.status !== 204 &&
                         response.headers.location == null &&
-                        this.captureMimeTypes.includes(response.mimeType)
+                        this.includeResponseBody(response)
                     ) {
                         const promise = this.client.send(
                             'Network.getResponseBody', { requestId },
@@ -103,12 +107,12 @@ class PuppeteerHar {
      * @returns {Promise<void|object>}
      */
     async stop() {
-        this.inProgress = false; 
+        this.inProgress = false;
         await Promise.all(this.response_body_promises);
         await this.client.detach();
         const har = harFromMessages(
             this.page_events.concat(this.network_events),
-            {includeTextFromResponseBody: this.saveResponse}
+            {includeTextFromResponseBody: this.includeResponseBody != null}
         );
         this.cleanUp();
         if (this.path) {


### PR DESCRIPTION
I wanted to have the ability to evaluate MIME types on the fly (using a regexp or otherwise) when deciding whether to include the response. The current API does not allow this.

I then realized that the MIME type is probably not the only thing you want to inspect for this decision. For example, you may want to look at a specific response header.

This PR replaces the `saveResponse` and `captureMimeTypes` options with a single `includeResponseBody` filter function that evaluates the response and returns true to include the body. I think this is much more flexible. Additionally, it removes ambiguity created by `captureMimeTypes` being ignored if `saveResponse` is false.

For backward compatibility, if `includeResponseBody` is not set, the code will fall back to the old logic by dynamically building a filter function.

I also wanted to pass the request to the filter function. However, linking the request to the response doesn't happen until the call to `harFromMessages`, which increased the complexity too much.